### PR TITLE
process() fix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,11 +80,20 @@ impl Plugin for Piano {
 		}
 	}
 	fn process(&mut self, buffer: &mut AudioBuffer<f32>) {
+		let output_channels = buffer.output_count();
+		let num_samples = buffer.samples();
 		let (_, output_buffer) = buffer.split();
-		for output_channel in output_buffer.into_iter() {
-			for output_sample in output_channel {
-				*output_sample = self.note.update();
+
+		for i in 0..num_samples {
+			let sample = self.note.update();
+			// Throw away a sample
+			let _ = self.note.update();
+
+			// Write the same sample to each of the channels (make it mono)
+			for out in output_buffer {
+				out[i] = sample;
 			}
+
 		}
 	}
 }


### PR DESCRIPTION
I just stole this code from one of my projects.. It's not pretty, but it works.

In your code, you basically have one "string" (with its own single "state"), and you're filling the buffer like this:

```
Left:   0  1  2  3  4  5 ...
Right: 90 91 92 93 94 95 ...
```

Instead of that, I made it mono and filled the buffer like this:

```
Left:   0  1  2  3  4  5 ...
Right:  0  1  2  3  4  5 ...
```

where the numbers are the sample number (i.e. the X-th sample out of `update`)

because I was calling `update` 1/2 the times you were, I fixed it by simply throwing away a sample in each iteration of the loop. You probably don't want to do this in your real VST.